### PR TITLE
Graceful exit

### DIFF
--- a/xplay/src/file.h
+++ b/xplay/src/file.h
@@ -21,18 +21,21 @@ class FileBuffer
         int *swapFillBuffers(void);
         SNDFILE *infile;            //TODO make private
         void signalFileReaderInitialized(void);
+        bool isNoMoreData(void);
+        void setFileReaderDone(void);
         int *getInitialReadBuffer(void);
         int *writeBuffer;
         int *readBuffer;
 
     private:
         bool fileReaderInitialized; 
+        bool fileReaderDone, noMoreData;
         bool readFull, writeFull;
         size_t bufSize;
         char * filename;
         SF_INFO sfinfo;     // libsndfile
         int filechannels;
-        std::condition_variable cvDoSwap, cvFileBufferInit; 
+        std::condition_variable cvDoSwap, cvFileBufferInit;
         std::mutex lock;
 };
 

--- a/xplay/src/inputchan.cpp
+++ b/xplay/src/inputchan.cpp
@@ -13,6 +13,12 @@ void FileWriter(WrFileBuffer &wrFileBuffer)
 
     while (1)     
     {
+        if (wrFileBuffer.isStopping())
+        {
+            wrFileBuffer.setStopped();
+            break;
+        }
+
         buf = wrFileBuffer.getReadBuffer();
         
         /* Note, libsnd file will do the converestion for use e.g. from wav 16 */
@@ -40,17 +46,17 @@ InputChan::InputChan(int chanCount, int sampRate)
 { 
     this->chanCount = chanCount;
     this->sampRate = sampRate;
-    this->done = false;
 }
 
-bool InputChan::getDone(void)
+bool FileInputChan::isDone(void)
 {
-    return done;
+    return wrFileBuffer->isStopped();
 }
 
 void FileInputChan::stop(void)
 {
-    // TODO
+    printf("input chan stop\n");
+    wrFileBuffer->setStopping();
 }
 
 FileInputChan::FileInputChan(char *filename, int chanCount, int sampleRate) : InputChan(chanCount, sampleRate) 
@@ -69,6 +75,6 @@ FileInputChan::FileInputChan(char *filename, int chanCount, int sampleRate) : In
 FileInputChan::~FileInputChan()
 {
     delete wrFileBuffer;
-    delete wrFileThread;
+    //delete wrFileThread;
 }
 

--- a/xplay/src/inputchan.cpp
+++ b/xplay/src/inputchan.cpp
@@ -55,7 +55,6 @@ bool FileInputChan::isDone(void)
 
 void FileInputChan::stop(void)
 {
-    printf("input chan stop\n");
     wrFileBuffer->setStopping();
 }
 

--- a/xplay/src/inputchan.cpp
+++ b/xplay/src/inputchan.cpp
@@ -40,6 +40,17 @@ InputChan::InputChan(int chanCount, int sampRate)
 { 
     this->chanCount = chanCount;
     this->sampRate = sampRate;
+    this->done = false;
+}
+
+bool InputChan::getDone(void)
+{
+    return done;
+}
+
+void FileInputChan::stop(void)
+{
+    // TODO
 }
 
 FileInputChan::FileInputChan(char *filename, int chanCount, int sampleRate) : InputChan(chanCount, sampleRate) 

--- a/xplay/src/inputchan.h
+++ b/xplay/src/inputchan.h
@@ -12,10 +12,15 @@ class InputChan
         virtual void consumeSample(int sample) = 0;
         int getChanCount(){return chanCount;};
         int getSampRate(){return sampRate;};
+        bool getDone(void);
+        virtual void stop(void) = 0;
     
     private:
         unsigned chanCount;
         unsigned sampRate;
+
+    protected:
+        bool done;
 };
 
 
@@ -26,6 +31,7 @@ class FileInputChan : public InputChan
         ~FileInputChan();
         void consumeSample(int sample);
         unsigned GetBufSize(void) {return bufSize;};
+        void stop(void);
 
     private:
         WrFileBuffer *wrFileBuffer;

--- a/xplay/src/inputchan.h
+++ b/xplay/src/inputchan.h
@@ -12,15 +12,12 @@ class InputChan
         virtual void consumeSample(int sample) = 0;
         int getChanCount(){return chanCount;};
         int getSampRate(){return sampRate;};
-        bool getDone(void);
+        virtual bool isDone(void) = 0;
         virtual void stop(void) = 0;
     
     private:
         unsigned chanCount;
         unsigned sampRate;
-
-    protected:
-        bool done;
 };
 
 
@@ -31,6 +28,7 @@ class FileInputChan : public InputChan
         ~FileInputChan();
         void consumeSample(int sample);
         unsigned GetBufSize(void) {return bufSize;};
+        bool isDone(void);
         void stop(void);
 
     private:

--- a/xplay/src/main.cpp
+++ b/xplay/src/main.cpp
@@ -350,5 +350,8 @@ int main(int argc, char *argv[])
         FreeSharedLibrary(hDLL);     
     }    
 
+    delete oc;
+    delete ic;
+
     return returnVal;
 }

--- a/xplay/src/outputchan.cpp
+++ b/xplay/src/outputchan.cpp
@@ -11,7 +11,7 @@ OutputChan::OutputChan(int x)
     this->done = false;
 }
 
-bool OutputChan::getDone(void)
+bool OutputChan::isDone(void)
 {
     return done;
 }
@@ -64,7 +64,7 @@ FileOutputChan::FileOutputChan(char *filename, int chanCount) : OutputChan(chanC
 FileOutputChan::~FileOutputChan()
 {
     delete fileBuffer;
-    delete fileThread;
+    //delete fileThread; // TODO
 }
 
 int FileOutputChan::getNextSample(void) 

--- a/xplay/src/outputchan.cpp
+++ b/xplay/src/outputchan.cpp
@@ -8,6 +8,12 @@
 OutputChan::OutputChan(int x) 
 { 
     this->chanCount = x;
+    this->done = false;
+}
+
+bool OutputChan::getDone(void)
+{
+    return done;
 }
 
 void FileReader(FileBuffer &fileBuffer)
@@ -32,8 +38,8 @@ void FileReader(FileBuffer &fileBuffer)
 
         if(readcount == 0)
         {
-            /* TODO properly handle EOF case */
-            exit(0);
+            fileBuffer.setFileReaderDone();
+            break;
         }
     }
 }
@@ -67,7 +73,15 @@ int FileOutputChan::getNextSample(void)
     {
         int *old = buf;
         buf = fileBuffer->swapFillBuffers();
-        count = this->bufSize;
+        if (fileBuffer->isNoMoreData())
+        {
+            done = true;
+            return 0;
+        }
+        else
+        {
+            count = this->bufSize;
+        }
     }
     
     int sample = buf[bufSize-count];

--- a/xplay/src/outputchan.h
+++ b/xplay/src/outputchan.h
@@ -15,7 +15,7 @@ class OutputChan
         virtual ~OutputChan() {};
         virtual int getNextSample(void) = 0;
         int getChanCount(){return chanCount;};
-        bool getDone(void);
+        bool isDone(void);
 
     private:
         unsigned chanCount;

--- a/xplay/src/outputchan.h
+++ b/xplay/src/outputchan.h
@@ -15,9 +15,13 @@ class OutputChan
         virtual ~OutputChan() {};
         virtual int getNextSample(void) = 0;
         int getChanCount(){return chanCount;};
+        bool getDone(void);
 
     private:
         unsigned chanCount;
+
+    protected:
+        bool done;
 };
 
 

--- a/xplay/src/wrfile.cpp
+++ b/xplay/src/wrfile.cpp
@@ -49,7 +49,6 @@ int *WrFileBuffer::getReadBuffer(void)
     /* Wait until write buffer is filled */
     cvDoSwap.wait(l, [this](){return (this->writeFull == true);});
 
-    //printf("got read buffer");
     readFull = true;
     writeFull = false;
 
@@ -80,6 +79,9 @@ WrFileBuffer::WrFileBuffer(size_t bufSize, char * filename, unsigned chanCount, 
     this->readFull = false;
     this->outfile = NULL;
 
+    this->stopping = false;
+    this->stopped = false;
+
     memset (&sfinfo, 0, sizeof (sfinfo)) ;
 
     /* Setup output file */
@@ -102,3 +104,27 @@ WrFileBuffer::WrFileBuffer(size_t bufSize, char * filename, unsigned chanCount, 
 }
 
 size_t WrFileBuffer::getBufferSize(void) { return bufSize; }
+
+void WrFileBuffer::setStopping(void)
+{
+    std::unique_lock<std::mutex> l(lock);
+    stopping = true;
+}
+
+void WrFileBuffer::setStopped(void)
+{
+    std::unique_lock<std::mutex> l(lock);
+    stopped = true;
+}
+
+bool WrFileBuffer::isStopping(void)
+{
+    std::unique_lock<std::mutex> l(lock);
+    return stopping;
+}
+
+bool WrFileBuffer::isStopped(void)
+{
+    std::unique_lock<std::mutex> l(lock);
+    return stopped;
+}

--- a/xplay/src/wrfile.h
+++ b/xplay/src/wrfile.h
@@ -19,6 +19,10 @@ class WrFileBuffer
         size_t getBufferSize();
         int *getReadBuffer(void);
         int *swapWriteBuffers(void);
+        void setStopping(void);
+        void setStopped(void);
+        bool isStopping(void);
+        bool isStopped(void);
         SNDFILE *outfile;            // TODO make private
         int *writeBuffer;            // "
         int *readBuffer;             // "
@@ -28,6 +32,7 @@ class WrFileBuffer
     private:
         bool fileWriterInitialized; 
         bool readFull, writeFull;
+        bool stopping, stopped;
         size_t bufSize;
         char * filename;
         SF_INFO sfinfo;     // libsndfile

--- a/xplay/src/xplay.cpp
+++ b/xplay/src/xplay.cpp
@@ -46,7 +46,7 @@ static int xplayCallback( const void *inputBuffer, void *outputBuffer,
     {
         for(int i = 0; i < framesPerBuffer; i++)
         {
-            if (!xplay->inChans->getDone())
+            if (!xplay->inChans->isDone())
             {
                 for (int j = 0; j < xplay->inChans->getChanCount(); j++) 
                 {
@@ -60,7 +60,7 @@ static int xplayCallback( const void *inputBuffer, void *outputBuffer,
     { 
         for(int i = 0; i < framesPerBuffer; i++)
         {
-            if (xplay->outChans->getDone())
+            if (xplay->outChans->isDone())
             {
                 if (xplay->inChans != NULL)
                 {
@@ -89,12 +89,12 @@ static int xplayCallback( const void *inputBuffer, void *outputBuffer,
 
     if (xplay->inChans != NULL)
     {
-        if (xplay->inChans->getDone())
+        if (xplay->inChans->isDone())
             return paComplete;
     }
-    if (xplay->outChans != NULL)
+    else if (xplay->outChans != NULL)
     {
-        if (xplay->outChans->getDone())
+        if (xplay->outChans->isDone())
             return paComplete;
     }
     return paContinue;

--- a/xplay/src/xplay.cpp
+++ b/xplay/src/xplay.cpp
@@ -46,9 +46,12 @@ static int xplayCallback( const void *inputBuffer, void *outputBuffer,
     {
         for(int i = 0; i < framesPerBuffer; i++)
         {
-            for (int j = 0; j < xplay->inChans->getChanCount(); j++) 
+            if (!xplay->inChans->getDone())
             {
-                xplay->inChans->consumeSample(*in++);
+                for (int j = 0; j < xplay->inChans->getChanCount(); j++) 
+                {
+                    xplay->inChans->consumeSample(*in++);
+                }
             }
         }
     }
@@ -57,10 +60,21 @@ static int xplayCallback( const void *inputBuffer, void *outputBuffer,
     { 
         for(int i = 0; i < framesPerBuffer; i++)
         {
-            for (int j = 0; j < xplay->outChans->getChanCount(); j++) 
+            if (xplay->outChans->getDone())
             {
-                int sample = xplay->outChans->getNextSample();
-                *out++ = sample;
+                if (xplay->inChans != NULL)
+                {
+                    xplay->inChans->stop();
+                    break;
+                }
+            }
+            else
+            {
+                for (int j = 0; j < xplay->outChans->getChanCount(); j++) 
+                {
+                    int sample = xplay->outChans->getNextSample();
+                    *out++ = sample;
+                }
             }
         }
     }
@@ -73,7 +87,17 @@ static int xplayCallback( const void *inputBuffer, void *outputBuffer,
         xplay->plugin->HandleSampleBuffer(framesPerBuffer, pluginBufIn, pluginBufOut);
     }
 
-    return 0;
+    if (xplay->inChans != NULL)
+    {
+        if (xplay->inChans->getDone())
+            return paComplete;
+    }
+    if (xplay->outChans != NULL)
+    {
+        if (xplay->outChans->getDone())
+            return paComplete;
+    }
+    return paContinue;
 }
 
 
@@ -138,10 +162,15 @@ int XPlay::run(unsigned delay, int device)
         return 1;
     }
 
-    if (delay == 0)
-        while (1);
-    else
-        Pa_Sleep(delay);
+    for (int i = 0; delay == 0 || i < delay; i++)
+    {
+        Pa_Sleep(1);
+        if ( !Pa_IsStreamActive( stream ) )
+              break;
+    }
+
+    if (delay > 0 && Pa_IsStreamActive( stream ) )
+        log("Timeout after %d msec\n", delay);
 
     err = Pa_StopStream( stream );
     if( err != paNoError ) 


### PR DESCRIPTION
Address #4 

Confirmed that actually calling record path destructor leads to invoking `sf_close` so that WAV file header gets properly filled in

Also closing down playback path and record path when no more playback data