### PR TITLE
Set the maximum play time to indefinite.

### DIFF
--- a/xplay/src/main.cpp
+++ b/xplay/src/main.cpp
@@ -332,8 +332,8 @@ int main(int argc, char *argv[])
 
     XPlay xplay(sampleRate, oc, ic, pi);
 
-    /* TODO duration should be while(1) (i.e. delay 0) by default or cmd line opt */
-    int duration = 100000;  
+    /* TODO Add a command line option to limit the audio play length to a specified duration. */
+    int duration = 0;  
     int returnVal = xplay.run(duration, device);
 
     if(options[PLUGIN])


### PR DESCRIPTION
Previously xplay limited the maximum time of playing audio to 100,000 ms, i.e. 1 minute 40 seconds.