### PR TITLE
Show channel count and sample rate in device list

### DIFF
--- a/xplay/src/main.cpp
+++ b/xplay/src/main.cpp
@@ -204,17 +204,17 @@ int main(int argc, char *argv[])
     }
 
     int device = -1;
-    const PaDeviceInfo *DeviceInfo;
+    const PaDeviceInfo *info;
     
     if(targetDevice < 0)
     {
         /* Look for a device to use */
         for (int i = 0; i < Pa_GetDeviceCount(); i++) 
         {
-            int curDevChanCountIn = Pa_GetDeviceInfo(i)->maxInputChannels;
+            info = Pa_GetDeviceInfo(i);
 
             const char * name = Pa_GetDeviceInfo(i)->name;
-            log("Found Device %d: %s\n", i, name);
+            log("Found Device %d: %-40s %dHz %din/%dout\n", i, name, (int)info->defaultSampleRate, info->maxInputChannels, info->maxOutputChannels);
 
             if(listDevices == false)
             {
@@ -222,7 +222,7 @@ int main(int argc, char *argv[])
                 {
                     char wdmIn[] = "Line (XMOS";
                     char wdmOut[] = "Speakers (XMOS";
-                    char *cmp = curDevChanCountIn == 0 ? wdmIn : wdmOut; 
+                    char *cmp = info->maxInputChannels == 0 ? wdmIn : wdmOut;
                     if (strstr(name, cmp) != NULL) 
                     {
                         log("Using Device %d: %s\n", i, name);

--- a/xplay/src/xplay.h
+++ b/xplay/src/xplay.h
@@ -19,7 +19,7 @@
 #define BUFFER_LENGTH (1024*4)
 
 #define XPLAY_VERSION_MAJOR 1
-#define XPLAY_VERSION_MINOR 1
+#define XPLAY_VERSION_MINOR 2
 
 typedef enum playmode{PLAYMODE_TONE, PLAYMODE_FILE, PLAYMODE_SILENCE} playmode_t;
 


### PR DESCRIPTION
Dual rate USB devices may not distinguish their recording and playback interfaces with descriptor strings. In the current xplay list output these show as two identical entries with no way of telling which is playback and which is record.

```
Found Device 2: XVF3510 (UAC1.0) Adaptive
Found Device 3: XVF3510 (UAC1.0) Adaptive
```

Change this to more verbose output:

```
Found Device 2: XVF3510 (UAC1.0) Adaptive                16000Hz 0in/2out
Found Device 3: XVF3510 (UAC1.0) Adaptive                48000Hz 2in/0out
```

Increase version to 1.2